### PR TITLE
Fix typos

### DIFF
--- a/en/docs/06.md
+++ b/en/docs/06.md
@@ -51,33 +51,33 @@ Example) Creation of a virtual environment
 
 ```
 [username@es1 ~]$ module load python/2.7/2.7.15
-[username@es1 ~]$ virtualenv hoo
-New python executable in /fs3/home/username/work/bin/python2.7
-Also creating executable in /fs3/home/username/work/bin/python
+[username@es1 ~]$ virtualenv env1
+New python executable in /home/username/env1/bin/python2.7
+Also creating executable in /home/username/env1/bin/python
 Installing setuptools, pip, wheel...done.
 ```
 
 Example) Activating a virtual environment
 
 ```
-[username@es1 ~]$ source work/bin/activate
-(work) [username@es1 ~]$
-(hoo) [username@es1 ~]$ which python
-/fs3/home/username/work/bin/python
-(hoo) [username@es1 ~]$ which pip
-/fs3/home/username/work/bin/pip
+[username@es1 ~]$ source env1/bin/activate
+(env1) [username@es1 ~]$
+(env1) [username@es1 ~]$ which python
+~/env1/bin/python
+(env1) [username@es1 ~]$ which pip
+~/env1/bin/pip
 ```
 
 Example) Installing numpy to a virtual environment
 
 ```
-(work) [username@es1 ~]$ pip install numpy
+(env1) [username@es1 ~]$ pip install numpy
 ```
 
 Example) Deactivating a virtual environment
 
 ```
-(work) [username@es1 ~]$ deactivate
+(env1) [username@es1 ~]$ deactivate
 [username@es1 ~]$
 ```
 

--- a/ja/docs/06.md
+++ b/ja/docs/06.md
@@ -53,33 +53,33 @@ ABCIが提供する`virtualenv`や`venv`を使って、軽量な仮想環境を�
 
 ```
 [username@es1 ~]$ module load python/2.7/2.7.15
-[username@es1 ~]$ virtualenv hoo
-New python executable in /fs3/home/username/work/bin/python2.7
-Also creating executable in /fs3/home/username/work/bin/python
+[username@es1 ~]$ virtualenv env1
+New python executable in /home/username/env1/bin/python2.7
+Also creating executable in /home/username/env1/bin/python
 Installing setuptools, pip, wheel...done.
 ```
 
 例) 仮想環境の有効化
 
 ```
-[username@es1 ~]$ source work/bin/activate
-(work) [username@es1 ~]$
-(hoo) [username@es1 ~]$ which python
-/fs3/home/username/work/bin/python
-(hoo) [username@es1 ~]$ which pip
-/fs3/home/username/work/bin/pip
+[username@es1 ~]$ source env1/bin/activate
+(env1) [username@es1 ~]$
+(env1) [username@es1 ~]$ which python
+~/env1/bin/python
+(env1) [username@es1 ~]$ which pip
+~/env1/bin/pip
 ```
 
 例) 仮想環境へnumpyをインストール
 
 ```
-(work) [username@es1 ~]$ pip install numpy
+(env1) [username@es1 ~]$ pip install numpy
 ```
 
 例) 仮想環境の無効化
 
 ```
-(work) [username@es1 ~]$ deactivate
+(env1) [username@es1 ~]$ deactivate
 [username@es1 ~]$
 ```
 


### PR DESCRIPTION
virtualenv の記述のところ、"hoo" で作った場合と "work" で作った場合のものが混じっているようでしたので、"env1" で統一しました。"env1" でなくても良いのですが、次の python3 + venv を別途使う人のことを考えて "work" じゃないものの方が良いと考えました。